### PR TITLE
ClamAV malware scanner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ ARG BRANCH=master
 
 FROM digiserve/service-cli:${BRANCH}
 
+# Can skip this step if digiserve/service-cli is refreshed recently
+apt-get update
+
+apt-get install -y clamav clamav-daemon
+
 COPY . /app
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ ARG BRANCH=master
 FROM digiserve/service-cli:${BRANCH}
 
 # Can skip this step if digiserve/service-cli is refreshed recently
-apt-get update
+RUN apt-get update
 
-apt-get install -y clamav clamav-daemon
+RUN apt-get install -y clamav clamav-daemon
 
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ FROM digiserve/service-cli:${BRANCH}
 RUN apt-get update
 
 RUN apt-get install -y clamav clamav-daemon
+RUN mkdir /var/run/clamav
+RUN chown clamav:clamav /var/run/clamav
 
 COPY . /app
 

--- a/app.js
+++ b/app.js
@@ -4,8 +4,26 @@
 //
 // const path = require("path");
 const AB = require("ab-utils");
+const child_process = require("child_process");
 
 var controller = AB.controller("file_processor");
 // controller.afterStartup((cb)=>{ return cb(/* err */) });
 // controller.beforeShutdown((cb)=>{ return cb(/* err */) });
 controller.init();
+
+if (process.env.CLAMAV_ENABLED == "true") {
+	child_process.execFile(
+		"chown",
+		[ "-R", "clamav:clamav", "/var/lib/clamav" ],
+		(err, stdout, stderr) => {
+			if (err) {
+				console.error("Could not initialize clamav volume.")
+				console.error(stderr);
+				console.error(err);
+			} else {
+				// Automatically refresh virus definition DB throughout the day
+				child_process.execFile("freshclam", [ "-d" ]);
+			}
+		}
+	);
+}

--- a/app.js
+++ b/app.js
@@ -12,28 +12,28 @@ var controller = AB.controller("file_processor");
 controller.init();
 
 if (process.env.CLAMAV_ENABLED == "true") {
-	child_process.execFile(
-		"chown",
-		[ "-R", "clamav:clamav", "/var/lib/clamav" ],
-		(err, stdout, stderr) => {
-			if (err) {
-				console.error("Could not initialize clamav volume.")
-				console.error(stderr);
-				console.error(err);
-			} else {
-				// Automatically refresh virus definition DB throughout the day
-				child_process.execFile("freshclam", [ "-d", "--daemon-notify" ]);
-				// Load the ClamAV daemon
-				child_process.execFile("clamd", (err, stdout, stderr) => {
-					if (err) {
-						console.error("Could not start ClamAV daemon.")
-						console.error(stderr);
-						console.error(err);
-					} else {
-						console.log("ClamAV daemon ready");
-					}
-				});
-			}
-		}
-	);
+   child_process.execFile(
+      "chown",
+      ["-R", "clamav:clamav", "/var/lib/clamav"],
+      (err, stdout, stderr) => {
+         if (err) {
+            console.error("Could not initialize clamav volume.");
+            console.error(stderr);
+            console.error(err);
+         } else {
+            // Automatically refresh virus definition DB throughout the day
+            child_process.execFile("freshclam", ["-d", "--daemon-notify"]);
+            // Load the ClamAV daemon
+            child_process.execFile("clamd", (err, stdout, stderr) => {
+               if (err) {
+                  console.error("Could not start ClamAV daemon.");
+                  console.error(stderr);
+                  console.error(err);
+               } else {
+                  console.log("ClamAV daemon ready");
+               }
+            });
+         }
+      }
+   );
 }

--- a/app.js
+++ b/app.js
@@ -22,7 +22,17 @@ if (process.env.CLAMAV_ENABLED == "true") {
 				console.error(err);
 			} else {
 				// Automatically refresh virus definition DB throughout the day
-				child_process.execFile("freshclam", [ "-d" ]);
+				child_process.execFile("freshclam", [ "-d", "--daemon-notify" ]);
+				// Load the ClamAV daemon
+				child_process.execFile("clamd", (err, stdout, stderr) => {
+					if (err) {
+						console.error("Could not start ClamAV daemon.")
+						console.error(stderr);
+						console.error(err);
+					} else {
+						console.log("ClamAV daemon ready");
+					}
+				});
 			}
 		}
 	);


### PR DESCRIPTION
To enable this feature, set environment variable `CLAMAV_ENABLED=true`.

Any file that is uploaded through the `file_processor.file-upload` handler will be scanned for malware. If ClamAV detects malware, the file will be deleted and the upload will fail. An HTTP 400 error response will be sent to the client:

```json
{
    "status": "error",
    "message": "Error: Malware detected in upload"
}
```

### Notes
There are two ways of running a scan. Either `clamscan` or `clamdscan`. The first way is the standalone scanner, which takes a significant amount of time to initialize. It causes up to 15 seconds of delay per file upload. The second way is through the ClamAV daemon. ClamAV permanently loads itself into memory, so it doesn't need to initialize for every scan. Scans are faster, but the memory is not freed up while idle. The second way was used in this PR.

This feature should only be enabled on servers with at least 3GB *extra* memory. Otherwise, the server OS may kill the entire file_processor container when it runs out of RAM.