### PR TITLE
fix filenames with "(" in them cause errors on the shell command line

### DIFF
--- a/handlers/file-get.js
+++ b/handlers/file-get.js
@@ -60,7 +60,7 @@ module.exports = {
          const fileObject = AB.objectFile();
          const SiteFile = fileObject.model();
          const entry = await req.retry(() =>
-            SiteFile.find({ uuid: req.param("uuid") })
+            SiteFile.find({ uuid: req.param("uuid") }),
          );
          const file = entry[0];
          if (file == null) {
@@ -87,7 +87,7 @@ module.exports = {
                   const newFileExtension = req.param("extension") || "webp";
                   const newFilePath = path.join(
                      parsedFilePath.dir,
-                     `${parsedFilePath.name}.${newFileExtension}`
+                     `${parsedFilePath.name}.${newFileExtension}`,
                   );
                   errorContext = `The file extension "${newFileExtension}" is invalid.`;
                   if (!fileObject.validExtension(newFilePath))
@@ -95,7 +95,7 @@ module.exports = {
                   if (!(await pathUtils.checkPath(newFilePath))) {
                      if (await pathUtils.checkPath(filePath))
                         imageUtils.convert(filePath, newFilePath);
-                     break;
+                     // break;
                   }
                   filePath = newFilePath;
                }

--- a/utils/imageUtils.js
+++ b/utils/imageUtils.js
@@ -16,7 +16,7 @@ module.exports = {
 
       if (quality != null) args.push(`-quality ${quality}`);
       if (resize != null) args.push(`-resize ${resize}`);
-      args.push(imagePath, newImagePath);
+      args.push(`"${imagePath}"`, `"${newImagePath}"`);
       await new Promise((resolve, reject) => {
          exec(args.join(" "), (error) => {
             if (error) reject(error);
@@ -26,8 +26,8 @@ module.exports = {
    },
 
    rotate: async (imagePath, newImagePath, direction = "left") => {
-      const degree = (direction == "left" ? 270 : 90);
-      const cmd = `convert ${imagePath} -rotate ${degree} ${newImagePath}`;
+      const degree = direction == "left" ? 270 : 90;
+      const cmd = `convert "${imagePath}" -rotate ${degree} "${newImagePath}"`;
 
       return await new Promise((resolve, reject) => {
          exec(cmd, (error) => {
@@ -35,6 +35,5 @@ module.exports = {
             resolve();
          });
       });
-
-   }
+   },
 };


### PR DESCRIPTION
Encountered this error while watching the logs
```
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:

Error: Command failed: convert -auto-orient /data/admin/file_processor/8c0bb530-5074-11ee-90f4-3b4fe16341c7_images (38).jpeg /data/admin/file_processor/8c0bb530-5074-11ee-90f4-3b4fe16341c7_images (38).webp

/bin/sh: 1: Syntax error: "(" unexpected
    at ChildProcess.exithandler (node:child_process:419:12)
    at ChildProcess.emit (node:events:513:28)
    at ChildProcess.emit (node:domain:489:12)
    at maybeClose (node:internal/child_process:1091:16)
    at Socket.<anonymous> (node:internal/child_process:449:11)
    at Socket.emit (node:events:513:28)
    at Socket.emit (node:domain:489:12)
    at Pipe.<anonymous> (node:net:322:12)
    at Pipe.callbackTrampoline (node:internal/async_hooks:130:17)
file_processor.error_handling::"Error: unhandledRejection:"
file_processor.error_handling::{"code":2,"killed":false,"signal":null,"cmd":"convert -auto-orient /data/admin/file_processor/8c0bb530-5074-11ee-90f4-3b4fe16341c7_images (38).jpeg /data/admin/file_processor/8c0bb530-5074-11ee-90f4-3b4fe16341c7_images (38).webp"}
```



## Release Notes
<!-- #release_notes -->
- [fix] fix filenames with "(" in them cause errors on the shell command line
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
